### PR TITLE
Update trendKalman.R

### DIFF
--- a/R/trendKalman.R
+++ b/R/trendKalman.R
@@ -41,9 +41,12 @@ kalman = function(data, sd = 0.003) {
     toProb = 1
     if (!is.null(data$options) && data$options$measure == "s")
         toProb = data$options$normalize
-
-    pollData[, `:=`(var = getPollVar(value/toProb, n),
-                    n = NULL)]
+    
+    if(!is.null(data$options) && !data$options$by.party.var)
+        pollData[, `:=`(var = .25 / n, n = NULL)]
+    else      
+        pollData[, `:=`(var = getPollVar(value/toProb, n),
+                        n = NULL)]
 
     trendData = data.table()
 


### PR DESCRIPTION
Create option (by.party.var) to allow for variance to be calculated at the poll level rather than the poll-by-party level. 

If by.party.var == F, the variance for each polling estimate will be 0.25 (maximum binomial variance) / n.